### PR TITLE
Separate invalidation from changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Upgrade `graphql-norm` package and switch to jest for testing. See PR [#12](https://github.com/dividab/graphql-norm-patch/pull/12).
 
+### Added
+
+- Separate patches for invalidation into its own union type and add functions `applyChanges`, `applyInvalidations`. See PR [#13](https://github.com/dividab/graphql-norm-patch/pull/13).
+
 ## [v0.14.0] - 2019-07-06
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "husky": "^0.14.3",
     "jest": "^24.9.0",
     "lint-staged": "^7.2.2",
-    "prettier": "^1.14.2",
+    "prettier": "^1.18.2",
     "rimraf": "^2.6.2",
     "ts-jest": "^24.1.0",
     "ts-node": "^8.4.1",

--- a/src/apply.ts
+++ b/src/apply.ts
@@ -12,14 +12,12 @@ interface MutableEntityCache {
   [id: string]: NormObj;
 }
 
-export function apply(
-  patches: ReadonlyArray<CachePatch.CachePatch>,
-  cache: NormMap,
-  staleMap: StaleMap
-): [NormMap, StaleMap] {
-  if (patches.length === 0) {
-    return [cache, staleMap];
-  }
+export function split(
+  patches: ReadonlyArray<CachePatch.CachePatch>
+): [
+  ReadonlyArray<CachePatch.ChangePatch>,
+  ReadonlyArray<CachePatch.InvalidationPatch>
+] {
   const changePatches: Array<CachePatch.ChangePatch> = [];
   const invalidationPatches: Array<CachePatch.InvalidationPatch> = [];
   for (const patch of patches) {
@@ -42,6 +40,18 @@ export function apply(
         exhaustiveCheck(patch);
     }
   }
+  return [changePatches, invalidationPatches];
+}
+
+export function apply(
+  patches: ReadonlyArray<CachePatch.CachePatch>,
+  cache: NormMap,
+  staleMap: StaleMap
+): [NormMap, StaleMap] {
+  if (patches.length === 0) {
+    return [cache, staleMap];
+  }
+  const [changePatches, invalidationPatches] = split(patches);
   const newCache = applyChanges(changePatches, cache);
   const newStale = applyInvalidations(invalidationPatches, newCache, staleMap);
   return [newCache, newStale];

--- a/src/apply.ts
+++ b/src/apply.ts
@@ -15,25 +15,49 @@ interface MutableEntityCache {
 export function apply(
   patches: ReadonlyArray<CachePatch.CachePatch>,
   cache: NormMap,
-  staleEntities: StaleMap
+  staleMap: StaleMap
 ): [NormMap, StaleMap] {
   if (patches.length === 0) {
-    return [cache, staleEntities];
+    return [cache, staleMap];
+  }
+  const changePatches: Array<CachePatch.ChangePatch> = [];
+  const invalidationPatches: Array<CachePatch.InvalidationPatch> = [];
+  for (const patch of patches) {
+    switch (patch.type) {
+      case "InvalidateEntity":
+      case "InvalidateField":
+        invalidationPatches.push(patch);
+        break;
+      case "CreateEntity":
+      case "DeleteEntity":
+      case "InsertElement":
+      case "RemoveElement":
+      case "RemoveEntityElement":
+      case "UpdateEntity":
+      case "UpdateField":
+        changePatches.push(patch);
+        break;
+      default:
+        const exhaustiveCheck = (x: never) => x;
+        exhaustiveCheck(patch);
+    }
+  }
+  const newCache = applyChanges(changePatches, cache);
+  const newStale = applyInvalidations(invalidationPatches, newCache, staleMap);
+  return [newCache, newStale];
+}
+
+export function applyChanges(
+  patches: ReadonlyArray<CachePatch.ChangePatch>,
+  cache: NormMap
+): NormMap {
+  if (patches.length === 0) {
+    return cache;
   }
   // Make a shallow copy of the cache
   let cacheCopy: MutableEntityCache = { ...cache };
-  // Make a shallow copy of the stale entities
-  let staleEntitiesCopy: MutableStaleEntities = { ...staleEntities };
   for (const patch of patches) {
     switch (patch.type) {
-      case "InvalidateEntity": {
-        applyInvalidateEntity(patch, cacheCopy, staleEntitiesCopy);
-        break;
-      }
-      case "InvalidateField": {
-        applyInvalidateField(patch, cacheCopy, staleEntitiesCopy);
-        break;
-      }
       case "CreateEntity": {
         applyCreateEntity(patch, cacheCopy);
         break;
@@ -69,7 +93,37 @@ export function apply(
     }
   }
 
-  return [cacheCopy, staleEntitiesCopy];
+  return cacheCopy;
+}
+
+export function applyInvalidations(
+  patches: ReadonlyArray<CachePatch.InvalidationPatch>,
+  cache: NormMap,
+  staleMap: StaleMap
+): StaleMap {
+  if (patches.length === 0) {
+    return staleMap;
+  }
+  // Make a shallow copy of the stale entities
+  let staleEntitiesCopy: MutableStaleEntities = { ...staleMap };
+  for (const patch of patches) {
+    switch (patch.type) {
+      case "InvalidateEntity": {
+        applyInvalidateEntity(patch, cache, staleEntitiesCopy);
+        break;
+      }
+      case "InvalidateField": {
+        applyInvalidateField(patch, cache, staleEntitiesCopy);
+        break;
+      }
+      default: {
+        const exhaustiveCheck = (x: never) => x;
+        exhaustiveCheck(patch);
+      }
+    }
+  }
+
+  return staleEntitiesCopy;
 }
 
 function applyInvalidateEntity(
@@ -123,7 +177,7 @@ function applyInvalidateField(
   }
 }
 
-export declare type Mutable<T> = { -readonly [P in keyof T]: T[P] };
+type Mutable<T> = { -readonly [P in keyof T]: T[P] };
 
 function invalidateRecursive(
   cache: NormMap,

--- a/src/cache-patch.ts
+++ b/src/cache-patch.ts
@@ -1,9 +1,9 @@
 import * as GraphQLCache from "graphql-norm";
 
-// A definition of an operation that modifies an entity
-export type CachePatch =
-  | InvalidateEntity
-  | InvalidateField
+export type CachePatch = ChangePatch | InvalidationPatch;
+
+// A definition of an operation that modifies fields in the cache
+export type ChangePatch =
   | CreateEntity
   | DeleteEntity
   | UpdateEntity
@@ -11,6 +11,9 @@ export type CachePatch =
   | InsertElement
   | RemoveElement
   | RemoveEntityElement;
+
+// A definition of an operation that invalidates fields in the cache
+export type InvalidationPatch = InvalidateEntity | InvalidateField;
 
 export interface InvalidateEntity {
   readonly type: "InvalidateEntity";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export * from "./cache-patch";
-export { apply } from "./apply";
+export { apply, applyChanges, applyInvalidations } from "./apply";

--- a/yarn.lock
+++ b/yarn.lock
@@ -3062,9 +3062,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@^1.14.2:
-  version "1.14.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.2.tgz#0ac1c6e1a90baa22a62925f41963c841983282f9"
+prettier@^1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
 
 pretty-format@^23.5.0:
   version "23.5.0"


### PR DESCRIPTION
Sometimes it is nice to handle changes to the cache map, and changes to the staleness map separately. This PR will add separate union types for cache changes, and invalidation changes. The old union type still exists (as a union of the separate types), and the old apply function still exists. So this change should be backwards compatible.